### PR TITLE
Fixed invalid pagelayout variable in contact form post submit template

### DIFF
--- a/app/Resources/views/full/contact_form_submitted.html.twig
+++ b/app/Resources/views/full/contact_form_submitted.html.twig
@@ -1,4 +1,4 @@
-{% extends noLayout == true ? viewbaseLayout : pagelayout %}
+{% extends ezpublish.configResolver.parameter('pagelayout') %}
 
 {% block content %}
     <div class="top-separator"></div>


### PR DESCRIPTION
> JIRA: http://jira.ez.no/browse/EZP-25737

Uses `app.configResolver()` to read the setting. It is the ugliest method, but also the most limited scope wise. A solution will have to be found either in a higher layer in the demo, or in platform itself (discussed in the issue).