### PR TITLE
Improved Symfony 3 compatibility

### DIFF
--- a/app/config/views.yml
+++ b/app/config/views.yml
@@ -1,7 +1,7 @@
 ezpublish:
     system:
         default:
-            pagelayout: "pagelayout.html.twig"
+            pagelayout: pagelayout.html.twig
             user:
                 layout: pagelayout.html.twig
 

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -1,101 +1,87 @@
-parameters:
-    app.installer.class: AppBundle\Installer\AppInstaller
-    app.criteria.menu.class: AppBundle\Criteria\Menu
-    app.controller.menu.class: AppBundle\Controller\MenuController
-    app.criteria.children.class: AppBundle\Criteria\Children
-    app.controller.blog.class: AppBundle\Controller\BlogController
-    app.controller.home.class: AppBundle\Controller\HomeController
-    app.controller.contactform.class: AppBundle\Controller\ContactFormController
-    app.form.type.contact.class: AppBundle\Form\Type\ContactType
-    app.form.contact.form.class: AppBundle\Form\Contact\Form
-    app.entity.message.class: AppBundle\Entity\Message
-    app.mail.sender.class: AppBundle\Mail\Sender
-    app.controller.gallery.class: AppBundle\Controller\GalleryController
-
 services:
     app.installer:
         parent: ezplatform.installer.db_based_installer
-        class: %app.installer.class%
+        class: AppBundle\Installer\AppInstaller
         tags:
             - { name: ezplatform.installer, type: demo }
 
     app.criteria.menu:
-        class: %app.criteria.menu.class%
+        class: AppBundle\Criteria\Menu
 
     app.controller.menu:
-        class: %app.controller.menu.class%
+        class: AppBundle\Controller\MenuController
         arguments:
-            - @templating
-            - @ezpublish.api.service.search
-            - @ezpublish.api.service.location
-            - @ezpublish.config.resolver
-            - @app.criteria.menu
-            - %app.top_menu.location_id%
+            - '@templating'
+            - '@ezpublish.api.service.search'
+            - '@ezpublish.api.service.location'
+            - '@ezpublish.config.resolver'
+            - '@app.criteria.menu'
+            - '%app.top_menu.location_id%'
 
     app.criteria.children:
-        class: %app.criteria.children.class%
+        class: AppBundle\Criteria\Children
 
     app.controller.blog:
-        class: %app.controller.blog.class%
+        class: AppBundle\Controller\BlogController
         arguments:
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.search
-            - @ezpublish.api.service.location
-            - @ezpublish.config.resolver
-            - @app.criteria.children
-            - %app.blog_post.random_posts_limit%
-            - %app.blog_post_list_limit%
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.search'
+            - '@ezpublish.api.service.location'
+            - '@ezpublish.config.resolver'
+            - '@app.criteria.children'
+            - '%app.blog_post.random_posts_limit%'
+            - '%app.blog_post_list_limit%'
 
     app.controller.home:
-        class: %app.controller.home.class%
+        class: AppBundle\Controller\HomeController
         arguments:
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.search
-            - @ezpublish.api.service.location
-            - @ezpublish.config.resolver
-            - @app.criteria.children
-            - %app.home.blog_post_limit%
-            - %app.home.blog_location_id%
-            - %app.home.gallery_image_limit%
-            - %app.home.gallery_location_id%
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.search'
+            - '@ezpublish.api.service.location'
+            - '@ezpublish.config.resolver'
+            - '@app.criteria.children'
+            - '%app.home.blog_post_limit%'
+            - '%app.home.blog_location_id%'
+            - '%app.home.gallery_image_limit%'
+            - '%app.home.gallery_location_id%'
 
     app.form.type.contact:
-        class: %app.form.type.contact.class%
+        class: AppBundle\Form\Type\ContactType
         tags:
             - { name: form.type, alias: app_contact }
 
     app.entity.message:
-        class: %app.entity.message.class%
+        class: AppBundle\Entity\Message
 
     app.form.contact.form:
-        class: %app.form.contact.form.class%
+        class: AppBundle\Form\Contact\Form
         arguments:
-            - @app.entity.message
-            - @app.form.type.contact
-            - @form.factory
+            - '@app.entity.message'
+            - '@app.form.type.contact'
+            - '@form.factory'
 
     app.controller.contactform:
-        class: %app.controller.contactform.class%
+        class: AppBundle\Controller\ContactFormController
         arguments:
-            - @app.form.type.contact
-            - @app.form.contact.form
-            - @app.mail.sender
-            - @templating
-            - @hautelook.router.template
-            - %app.contact_form.sender_email%
-            - %app.contact_form.recipient_email%
-            - %app.contact_form.email_title%
+            - '@app.form.type.contact'
+            - '@app.form.contact.form'
+            - '@app.mail.sender'
+            - '@templating'
+            - '@hautelook.router.template'
+            - '%app.contact_form.sender_email%'
+            - '%app.contact_form.recipient_email%'
+            - '%app.contact_form.email_title%'
 
     app.mail.sender:
-        class: %app.mail.sender.class%
+        class: AppBundle\Mail\Sender
         arguments:
-            - @mailer
+            - '@mailer'
 
     app.controller.gallery:
-        class: %app.controller.gallery.class%
+        class: AppBundle\Controller\GalleryController
         arguments:
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.search
-            - @ezpublish.config.resolver
-            - @app.criteria.children
-            - %app.gallery.images_limit%
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.search'
+            - '@ezpublish.config.resolver'
+            - '@app.criteria.children'
+            - '%app.gallery.images_limit%'


### PR DESCRIPTION
Some improvements to existing services configuration:
- removed class names as parameters as they are not recommended starting from sf 2.8 (http://symfony.com/doc/current/best_practices/business-logic.html#service-no-class-parameter),
- added quotation marks to services names required by sf 3.