### PR TITLE
Standardize on 'app' as the application name

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -2,7 +2,7 @@
 # in the same project.
 
 # The name of this app. Must be unique within a project.
-name: front
+name: app
 
 # The type of the application to build.
 type: php:7.0


### PR DESCRIPTION
We've done this for all of the Platform-sh-maintained repos, so may as well do it for yours, too.