### PR TITLE
Use PreContentViewListener to inject global parameters in content views

### DIFF
--- a/app/Resources/views/pagelayout_footer.html.twig
+++ b/app/Resources/views/pagelayout_footer.html.twig
@@ -16,7 +16,7 @@
                     </p>
                 </div>
                 <div class="col-md-3 col-md-offset-1 space-top-half-bit space-bottom-less">
-                    <a class="btn btn-primary btn-lg small" href="{{ path('ez_urlalias', {locationId: contactLocationId}) }}">{{ 'Get in touch!'|trans }}</a>
+                    <a class="btn btn-primary btn-lg small" href="{% if contactLocationId is defined %}{{ path('ez_urlalias', {locationId: contactLocationId}) }}{% else %}#{% endif %}">{{ 'Get in touch!'|trans }}</a>
                 </div>
             </div>
         </div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -83,8 +83,6 @@ framework:
 twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
-    globals:
-        contactLocationId: %app.layout.contact_location_id%
 
 # Assetic Configuration
 assetic:

--- a/src/AppBundle/EventListener/PreContentViewListener.php
+++ b/src/AppBundle/EventListener/PreContentViewListener.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace AppBundle\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
+
+/**
+ * Event listener used for injecting parameters in content views.
+ */
+class PreContentViewListener
+{
+    /** @var array */
+    private $options;
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function onPreContentView(PreContentViewEvent $event)
+    {
+        $contentView = $event->getContentView();
+        $contentView->addParameters($this->options);
+    }
+}

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -23,6 +23,13 @@ services:
         tags:
             - { name: ezpublish.query_type }
 
+    app.pre_content_view_listener:
+        class: AppBundle\EventListener\PreContentViewListener
+        arguments:
+            - contactLocationId: '%app.layout.contact_location_id%'
+        tags:
+            - { name: kernel.event_listener, event: ezpublish.pre_content_view, method: onPreContentView }
+
     app.criteria.menu:
         class: AppBundle\Criteria\Menu
 


### PR DESCRIPTION
Every day's a school day... found this today (available since 2014: https://doc.ez.no/display/EZP/Parameters+injection+in+content+views).

Submitted as a proof of concept to show that we can inject parameters in a - better - way :)
Perhaps it would be good idea to demonstrate this feature to other developers?

If not, don't hesitate to close it :)