### PR TITLE
Add config files for Platform.sh directly to eZ Platform Demo

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,0 +1,65 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: php:7.0
+build:
+    flavor: composer
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "mysqldb:mysql"
+    redis: "rediscache:redis"
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "web"
+            # The front-controller script to send non-static requests to.
+            passthru: "/app.php"
+            # The number of seconds whitelisted (static) content should be cache
+            expires: 600
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    "/app/cache": "shared:files/cache"
+    "/app/logs": "shared:files/logs"
+    "/web/var": "shared:files/files"
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    build: |
+        rm web/app_dev.php
+        app/console --env=prod assetic:dump
+    deploy: |
+        set -e
+        if [ ! -f web/var/.platform.installed ]; then
+            php -d memory_limit=-1 app/console ezplatform:install --env prod demo
+            touch web/var/.platform.installed
+        fi
+        app/console --env=prod cache:clear
+
+# The configuration of scheduled execution.
+# see http://symfony.com/doc/current/components/console/introduction.html
+#crons:
+#    symfony:
+#        spec: "*/20 * * * *"
+#        cmd: "php cron.php example:test"
+
+runtime:
+    extensions:
+        - xsl
+        - imagick
+        - redis
+        - readline

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,0 +1,11 @@
+"http://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+        # As this does not support Vary, and purging, we can't use this as Sf Proxy drop in.
+        # However it is possible to enable this for anonymous traffic when backend sends expiry headers.
+        enabled: false
+
+"http://www.{default}/":
+    type: redirect
+    to: "http://{default}/"

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,0 +1,6 @@
+mysqldb:
+    type: mysql:10.0
+    disk: 2048
+
+rediscache:
+    type: redis:3.0


### PR DESCRIPTION
from https://github.com/platformsh/platformsh-example-ezplatform

The purpose of adding these files is to move towards tracking Platform.sh configuration in the demo repo, rather than a dedicated Platform.sh repo, for the demo only. Given different use cases for the non-demo products, we will most likely continue to plan on using the Platform.sh repo for those.

Totally open for discussion. I know we had decided against this before, but I wanted to see where we stand now that we've walked down that road a little.