### PR TITLE
EZEE-1483: Added `twig/twig` to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": "~5.6|~7.0",
         "symfony/symfony": "~2.8",
+        "twig/twig": "~1.28",
         "twig/extensions": "~1.4",
         "symfony/assetic-bundle": "~2.8",
         "symfony/swiftmailer-bundle": "~2.5",


### PR DESCRIPTION
**JIRA: https://jira.ez.no/browse/EZEE-1483**

Recent change in the dependencies causes Twig 2.x to install instead of 1.x which was normally provided with our releases. We are not forcing any Twig version to install in our packages which results in broken eZ Platform EE demo installation. More explanations can be found in https://github.com/ezsystems/ezplatform-ee/pull/49