### PR TITLE
Removed english from SiteAccess Group conf

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -46,10 +46,6 @@ ezpublish:
             # it is recommended to install clean, then change setting before you start adding binary content, otherwise you'll
             # need to manually modify your database data to reflect this to avoid exceptions.
             var_dir: var/site
-            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
-            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
-            # all eng-GB data to other locales first.
-            languages: [eng-GB]
             content:
               # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
               # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased


### PR DESCRIPTION
Removed english language code from the SiteAccess Group configuration because languages are defined at the SiteAccess level.
By keeping it, `eng-GB` is always displayed even if the SiteAccess configuration defines `eng-GB` as a fallback language.