### PR TITLE
Add siteaccess limitation to user/login policy for anonymous and contributor users

### DIFF
--- a/src/AppBundle/MigrationVersions/users.yml
+++ b/src/AppBundle/MigrationVersions/users.yml
@@ -405,6 +405,10 @@
         -
             module: user
             function: login
+            limitations:
+                -
+                    identifier: SiteAccess
+                    values: [site, fr, de, no]
         -
             module: user
             function: register
@@ -461,6 +465,10 @@
         -
             module: user
             function: login
+            limitations:
+                -
+                    identifier: SiteAccess
+                    values: [site, fr, de, no]
         -
             module: user
             function: register


### PR DESCRIPTION
It is not wise to allow users unrestricted login to all siteaccesses, especially when we start to add more backend siteaccesses like Netgen Admin UI siteaccess and so on.

This restricts login for anonymous and contributor users only to frontend siteaccesses.
  