### PR TITLE
Change instanciation position of EzCoreExtraBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -30,7 +30,6 @@ class AppKernel extends Kernel
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
             new Novactive\Bundle\eZSEOBundle\NovaeZSEOBundle(),
             new \Kaliop\eZMigrationBundle\EzMigrationBundle(),
-            new Lolautruche\EzCoreExtraBundle\EzCoreExtraBundle(),
             // eZ Systems
             new EzSystems\PlatformHttpCacheBundle\EzSystemsPlatformHttpCacheBundle(),
             new eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle(),
@@ -50,6 +49,7 @@ class AppKernel extends Kernel
             new EzSystems\EzPlatformAdminUiAssetsBundle\EzPlatformAdminUiAssetsBundle(),
             new EzSystems\EzPlatformCronBundle\EzPlatformCronBundle(),
             // Dependencies
+            new Lolautruche\EzCoreExtraBundle\EzCoreExtraBundle(),
             new Netgen\TagsBundle\NetgenTagsBundle(),
             // Application
             new AppBundle\AppBundle(),


### PR DESCRIPTION
In order for all features of EzCoreExtraBundle to work, it must be instanciated after eZ dependencies.
This is mainly because of compiler passes priority mess.