### PR TITLE
EZP-30898: Changed Demo Installer parent in Symfony DIC

### DIFF
--- a/config/services/installer.yaml
+++ b/config/services/installer.yaml
@@ -6,7 +6,7 @@ services:
 
     App\Installer\PlatformDemoInstaller:
         autowire: true
-        parent: ezplatform.installer.db_based_installer
+        parent: EzSystems\PlatformInstallerBundle\Installer\CoreInstaller
         class: App\Installer\PlatformDemoInstaller
         calls:
             - [setEnvironment, ["%kernel.environment%"]]


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30898](https://jira.ez.no/browse/EZP-30898)
| **Requires** | <ul><li>ezsystems/BehatBundle#100</li><li>ezsystems/ezpublish-kernel#2751</li></ul>
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | eZ Platform Demo `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR sets Kernel (PlatformInstaller Bundle) `CoreInstaller` as `parent` in Dependency Injection Container configuration to align both with [the actual class implementation](https://github.com/ezsystems/ezplatform-demo/blob/a28c64247e5df35b0e1ce075f89dcddd03bc2e7d/src/Installer/PlatformDemoInstaller.php#L14) and the changes introduced via ezsystems/ezpublish-kernel#2751.

_It wasn't considered as a bug, because `CoreInstaller` was not explicitly defined in the Container in v2.5+, due to optional dependency on Doctrine Schema Bundle and resulting from that BC promise._