### PR TITLE
EZP-30906: Replaced Templating component with explicit Twig

### DIFF
--- a/src/Controller/MenuController.php
+++ b/src/Controller/MenuController.php
@@ -9,14 +9,14 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Templating\EngineInterface;
 use eZ\Publish\API\Repository\SearchService;
 use App\QueryType\MenuQueryType;
+use Twig\Environment as TwigEnvironment;
 
 final class MenuController
 {
-    /** @var \Symfony\Bundle\TwigBundle\TwigEngine */
-    protected $templating;
+    /** @var \Twig\Environment */
+    protected $twig;
 
     /** @var \eZ\Publish\API\Repository\SearchService */
     protected $searchService;
@@ -31,20 +31,20 @@ final class MenuController
     protected $topMenuContentTypeIdentifier;
 
     /**
-     * @param \Symfony\Component\Templating\EngineInterface $templating
+     * @param \Twig\Environment $twig
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \App\QueryType\MenuQueryType $menuQueryType
      * @param int $topMenuParentLocationId
      * @param array $topMenuContentTypeIdentifier
      */
     public function __construct(
-        EngineInterface $templating,
+        TwigEnvironment $twig,
         SearchService $searchService,
         MenuQueryType $menuQueryType,
         int $topMenuParentLocationId,
         array $topMenuContentTypeIdentifier
     ) {
-        $this->templating = $templating;
+        $this->twig = $twig;
         $this->searchService = $searchService;
         $this->menuQueryType = $menuQueryType;
         $this->topMenuParentLocationId = $topMenuParentLocationId;
@@ -81,11 +81,16 @@ final class MenuController
         $response = new Response();
         $response->setVary('X-User-Hash');
 
-        return $this->templating->renderResponse(
-            $template, [
-                'menuItems' => $menuItems,
-                'pathArray' => $pathArray,
-            ], $response
+        $response->setContent(
+            $this->twig->render(
+                $template,
+                [
+                    'menuItems' => $menuItems,
+                    'pathArray' => $pathArray,
+                ]
+            )
         );
+
+        return $response;
     }
 }

--- a/src/Mail/Sender.php
+++ b/src/Mail/Sender.php
@@ -12,7 +12,7 @@ use App\Model\Contact;
 use Swift_Mailer;
 use Swift_Message;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Environment as Templating;
+use Twig\Environment as TwigEnvironment;
 
 final class Sender
 {
@@ -22,8 +22,8 @@ final class Sender
     /** @var \Symfony\Component\Translation\TranslatorInterface */
     private $translator;
 
-    /** @var \Symfony\Bundle\TwigBundle\TwigEngine */
-    private $templating;
+    /** @var \Twig\Environment */
+    private $twig;
 
     /** @var string */
     private $senderEmail;
@@ -34,20 +34,20 @@ final class Sender
     /**
      * @param \Swift_Mailer $mailer
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator
-     * @param \Twig\Environment $templating
+     * @param \Twig\Environment $twig
      * @param string $senderEmail
      * @param string $recipientEmail
      */
     public function __construct(
         Swift_Mailer $mailer,
         TranslatorInterface $translator,
-        Templating $templating,
+        TwigEnvironment $twig,
         string $senderEmail,
         string $recipientEmail
     ) {
         $this->mailer = $mailer;
         $this->translator = $translator;
-        $this->templating = $templating;
+        $this->twig = $twig;
         $this->senderEmail = $senderEmail;
         $this->recipientEmail = $recipientEmail;
     }
@@ -69,7 +69,7 @@ final class Sender
             ->setTo($this->recipientEmail)
             ->setReplyTo($this->recipientEmail)
             ->setBody(
-                $this->templating->render('/themes/tastefulplanet/mail/contact.html.twig', [
+                $this->twig->render('/themes/tastefulplanet/mail/contact.html.twig', [
                     'contact' => $contact
                 ])
             );

--- a/templates/themes/admin/fields/eztags_field.html.twig
+++ b/templates/themes/admin/fields/eztags_field.html.twig
@@ -1,4 +1,4 @@
-{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+{% extends "@EzPublishCore/content_fields.html.twig" %}
 
 {% block eztags_field %}
     {#    {% for tag in field.value.tags %}#}

--- a/templates/themes/tastefulplanet/fields/eztags_field.html.twig
+++ b/templates/themes/tastefulplanet/fields/eztags_field.html.twig
@@ -1,4 +1,4 @@
-{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+{% extends "@EzPublishCore/content_fields.html.twig" %}
 
 {% block eztags_field %}
 {#    {% for tag in field.value.tags %}#}

--- a/templates/themes/tastefulplanet/pagelayout.html.twig
+++ b/templates/themes/tastefulplanet/pagelayout.html.twig
@@ -3,7 +3,7 @@
     <head>
         {% block seo_metas %}
             {% if location is defined and not location.isDraft %}
-{#                {% include "NovaeZSEOBundle::seometas_head.html.twig" %}#}
+{#                {% include "@NovaeZSEO/seometas_head.html.twig" %}#}
             {% endif %}
         {% endblock %}
         


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30906](https://jira.ez.no/browse/EZP-30906)
| **Type** | Bug
| **Target version** | `master` only

The integration of the Templating component has been deprecated in Symfony 4.3:
https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration

We've dropped that integration via ezsystems/ezplatform#453 so now every reference to `Templating` component needs to be replaced explicitly with `Twig\Environment`.

The other side effect of this is that referencing template via e.g. `AppBundle::my_template.twig` is no longer supported, we need to use `@App/my_template.twig` respectively.

## Steps to reproduce

Compiling container on ezplatform-demo and ezplatform-ee-demo fails on `master`.

## Background

The features I'm working on are best tested with demo instances, so this was the reason I needed this fixed soon ;)

**TODO**:
- [ ] Merge up to ezplatform-ee-demo