### PR TITLE
EZP-30948, EZP-30960: Dropped Setup and Design section removal

### DIFF
--- a/src/MigrationVersions/all.yml
+++ b/src/MigrationVersions/all.yml
@@ -42,17 +42,6 @@
         -
             identifier: ref_section__cuisines
             attribute: id
-# TODO: Error in execution of step 8: Argument 'section' has a bad state: section is still assigned to content
-#-
-#    type: section
-#    mode: delete
-#    match:
-#        identifier: setup
-#
-#-
-#    type: section
-#    mode: delete
-#        identifier: design
 
 ## Content types
 


### PR DESCRIPTION
"Setup" and "Design" Sections are being dropped via ezsystems/ezpublish-kernel#2768 so we can now resolve this Migrations "TODO" item by just dropping it.